### PR TITLE
get_rowsエンドポイントを実装した

### DIFF
--- a/WETHAP_API/db/infos.py
+++ b/WETHAP_API/db/infos.py
@@ -150,7 +150,6 @@ class InfosManager(TableManager):
             weather,
             id,
         )
-        print(query % params)
         return query, params
 
     def _remove(self, id: int) -> tuple[str, tuple]:
@@ -200,6 +199,27 @@ class InfosManager(TableManager):
             SELECT lab_id, date, time, num_gen, temperature, humidity, pressure, weather
             FROM {self.table} ORDER BY id
             """
+        )
+        records = self.cursor.fetchall()
+        return records
+
+    def get_rows(
+        self, lab_id: str, row_limit: int, descending: bool = True
+    ) -> list[INFO_TABLE_TYPES]:
+        """指定した研究室の最新のレコードを取得
+
+        Args:
+            lab_id (str): 研究室名
+            row_limit (int): 取得したい行数
+            descending (bool): date, timeの降順・昇順 どちらでレコード取得するか デフォルトで降順(True)
+
+        Returns:
+            list[INFO_TABLE_TYPES]: レコード
+        """
+        order = "DESC" if descending else "ASC"
+        self.cursor.execute(
+            f"SELECT * FROM {self.table} WHERE lab_id = %s ORDER BY date {order}, time {order} LIMIT %s;",
+            (lab_id, row_limit),
         )
         records = self.cursor.fetchall()
         return records

--- a/WETHAP_API/db/infos.py
+++ b/WETHAP_API/db/infos.py
@@ -130,7 +130,7 @@ class InfosManager(TableManager):
                 UPDATE {self.table} SET
                 lab_id = %s,
                 date = %s,
-                time = %s
+                time = %s,
                 num_gen = %s,
                 temperature = %s,
                 humidity = %s,
@@ -150,6 +150,7 @@ class InfosManager(TableManager):
             weather,
             id,
         )
+        print(query % params)
         return query, params
 
     def _remove(self, id: int) -> tuple[str, tuple]:

--- a/WETHAP_API/manual_db.py
+++ b/WETHAP_API/manual_db.py
@@ -7,8 +7,8 @@ from managers import infos_manager, sender_manager
 # infos_manager.create_table()
 # infos_manager.insert("テスト", str(datetime.date.today()), str(datetime.datetime.now()), 0, 0.0, 0.0, 0.0, "晴れ")
 # infos_manager.update(1, "更新", str(datetime.date.today()), str(datetime.datetime.now()), 1, 1.0, 1.0, 1.0, "雨")
+# print(infos_manager.get_rows(lab_id="テスト", row_limit=3))
 print(infos_manager.preview_data())
-
 
 # sender_manager.init_table()
 sender_manager.change_lab_id(before_lab_id="T4教室", after_lab_id="高野家")

--- a/WETHAP_API/manual_db.py
+++ b/WETHAP_API/manual_db.py
@@ -5,8 +5,8 @@ from managers import infos_manager, sender_manager
 # infos_manager.init_table()
 # infos_manager.delete_table()
 # infos_manager.create_table()
-# infos_manager.insert("テスト", str(datetime.date.today()), 0.0, 0.0, 0.0, 0.0, "晴れ")
-# infos_manager.update(10, "更新", str(datetime.date.today()), 1.0, 1.0, 1.0, 1.0, "雨")
+# infos_manager.insert("テスト", str(datetime.date.today()), str(datetime.datetime.now()), 0, 0.0, 0.0, 0.0, "晴れ")
+# infos_manager.update(1, "更新", str(datetime.date.today()), str(datetime.datetime.now()), 1, 1.0, 1.0, 1.0, "雨")
 print(infos_manager.preview_data())
 
 

--- a/WETHAP_API/routers/http_router.py
+++ b/WETHAP_API/routers/http_router.py
@@ -189,3 +189,17 @@ async def post_request_info(request: RequestInfo, response: Response):
     else:
         response.status_code = status.HTTP_400_BAD_REQUEST
         return {"status": "non active room"}
+
+
+@router.get("/get-rows")
+async def get_rows(labID: str, rowLimit: int, descending: bool = True):
+    response = infos_manager.get_rows(
+        lab_id=labID, row_limit=rowLimit, descending=descending
+    )
+    return response
+
+
+@router.get("/getInfo")
+async def get_a_info(labID: str, date: str, numGen: int):
+    response = infos_manager.select(lab_id=labID, date=date, num_gen=numGen)
+    return response if response else "NoData"

--- a/WETHAP_API/routers/http_router.py
+++ b/WETHAP_API/routers/http_router.py
@@ -197,9 +197,3 @@ async def get_rows(labID: str, rowLimit: int, descending: bool = True):
         lab_id=labID, row_limit=rowLimit, descending=descending
     )
     return response
-
-
-@router.get("/getInfo")
-async def get_a_info(labID: str, date: str, numGen: int):
-    response = infos_manager.select(lab_id=labID, date=date, num_gen=numGen)
-    return response if response else "NoData"


### PR DESCRIPTION
### get_rowsエンドポイント
指定した研究室の直近のデータを指定行数、dateとtimeの合わせた昇順・降順で取得する
lab_id, row_limit, descendingをクエリパラメータにとる

### fixしたところ
- manual_db.pyの、insertとupdateの例を、今使われているテーブルのスキームに合わせた(雑かも)
- `InfosManager`の内部関数`_update()`のSQL syntax error